### PR TITLE
fix missing dependency on pnpm

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "@element-plus/icons-vue": "^2.0.10",
+    "@vueuse/core": "^9.8.1",
     "element-plus": "^2.2.13",
     "vue": "^3.2.36",
     "vue-router": "4"


### PR DESCRIPTION
Fix the following errors:
```
The following dependencies are imported but could not be resolved:

  @element-plus/icons-vue (imported by /home/xeonacid/Documents/HIT-CS32301/lab/crypto-ca/front/src/components/Sign.vue?id=0)
  @vueuse/core (imported by /home/xeonacid/Documents/HIT-CS32301/lab/crypto-ca/front/src/composables/dark.ts)

Are they installed?
Failed to resolve import "@element-plus/icons-vue" from "src/components/Sign.vue". Does the file exist?
Failed to resolve import "@element-plus/icons-vue" from "src/components/Revoke.vue". Does the file exist?
Failed to resolve import "@element-plus/icons-vue" from "src/components/layouts/BaseSide.vue". Does the file exist?
Failed to resolve import "@vueuse/core" from "src/composables/dark.ts". Does the file exist?
```